### PR TITLE
Match confidence updated

### DIFF
--- a/app/views/reports/pdf.html.erb
+++ b/app/views/reports/pdf.html.erb
@@ -34,8 +34,8 @@
   <li><strong>Marketplace:</strong> <%= @report.match.marketplace %></li>
   <li><strong>Seller:</strong> <%= @report.match.seller %></li>
   <li><strong>Location:</strong> <%= @report.match.location %></li>
-  <li><strong>Match Confidence:</strong> 92%</li> <!-- static example, update if dynamic -->
-  <li><strong>Posted Date:</strong> 2 days ago</li> <!-- static example, update if dynamic -->
+  <li><strong>Match Confidence:</strong> <%= @report.match.match_score %>% </li>
+  <li><strong>Matched Fields:</strong> <%= @report.match.matched_fields.map(&:humanize).to_sentence %></li>
 </ul>
 
 <hr>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -61,8 +61,8 @@
         <p class="mb-1"><strong>Marketplace:</strong> <%= @report.match.marketplace %></p>
         <p class="mb-1"><strong>Seller:</strong> <%= @report.match.seller %></p>
         <p class="mb-1"><strong>Location:</strong> <%= @report.match.location %></p>
-        <p class="mb-1"><strong>Match Confidence:</strong> 92%</p> <!-- Example value -->
-        <p class="mb-0"><strong>Posted Date:</strong> 2 days ago</p> <!-- Example value -->
+        <p class="mb-1"><strong>Match Confidence:</strong> <%= @report.match.match_score %>% </p>
+        <p class="mb-1"><strong>Matched Fields:</strong> <%= @report.match.matched_fields.map(&:humanize).to_sentence %></p>
       </div>
     </div>
 


### PR DESCRIPTION
Hey all,

In the reports show, I added the real data for match confidence, and I change the posted date to the matched fields, I believe matched fields gives more real information than the posted date, in case you guys would prefer to have back the posted date, I can undo the matched fields, or let me know if something else would be better than it.


<img width="1031" height="481" alt="image" src="https://github.com/user-attachments/assets/853e67e0-95f1-4488-92dd-b7562d4a8642" />

<img width="519" height="249" alt="image" src="https://github.com/user-attachments/assets/e6687981-84b9-41b5-af23-f4d85b597e4d" />
