### PR TITLE
remove cancel button

### DIFF
--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -156,7 +156,6 @@
               </div>
             </div>
             <div class="modal-footer border-0">
-              <button type="button" class="btn btn-outline-custom" data-bs-dismiss="modal">Cancel</button>
               <%= f.button :submit, "Save changes", class: "btn btn-primary-custom" %>
             </div>
           <% end %>


### PR DESCRIPTION
<img width="1470" height="956" alt="Screenshot 2025-08-06 at 16 15 46" src="https://github.com/user-attachments/assets/a6aa21dc-6b33-40d8-b1c9-f7985fe11662" />
removed cancel button because there is already the cross on the right top that does the same 