### PR TITLE
Fix Go Back button style: right-aligned, dark grey, no border/background

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -77,3 +77,17 @@
   font-weight: 500;
   border-radius: 4px;
 }
+
+.back-button {
+  color: #555;
+  font-weight: 500;
+  text-decoration: none;
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  transition: color 0.3s ease;
+}
+
+.back-button:hover {
+  color: #000;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,8 +18,8 @@
 
     <%# Show back button only if referer exists and current page is not the root path %>
     <% if request.referer.present? && !current_page?(root_path) %>
-      <div class="container mt-3">
-        <%= link_to "← Go back", request.referer, class: "btn btn-outline-secondary btn-sm back-button" %>
+      <div class="container mt-3 d-flex justify-content-end">
+      <%= link_to "Go back", request.referer, class: "back-button" %>
       </div>
     <% end %>
 


### PR DESCRIPTION

Aligned the button to the right side of the page, styled it with dark grey text and hover color, removed border and background to keep it minimal and clean.
